### PR TITLE
fix browser arg for e2e grid mode

### DIFF
--- a/src/actions/e2e.ts
+++ b/src/actions/e2e.ts
@@ -59,7 +59,7 @@ async function init(options) {
     const { host, port, user, password } = selenium;
     options.seleniumUrl = `http://${user ? `${user}:${password}@` : ''}${host}:${port}/wd/hub`;
     browsers = options.browsers
-      ? options.browser.split(',').map(parseBrowser)
+      ? options.browsers.split(',').map(parseBrowser)
       : await getBrowsers();
 
     if (isSauceLabsHost(host)) {


### PR DESCRIPTION
Calling 
```
ws e2e -g --browsers ff-45
```
currently leads to the following error:
```
TypeError: Cannot read property 'split' of undefined
    at /var/lib/jenkins/workspace/ws-e2e-unite-sso/node_modules/@mercateo/ws/dist/webpack:/src/actions/e2e.ts:61:1
```

This PR fixes this.