### PR TITLE
Enhance electron workflow

### DIFF
--- a/examples/electron-ts-i18n/package.json
+++ b/examples/electron-ts-i18n/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "start": "electron .",
+    "start": "electron dist/electron.js",
     "ws": "node ../../bin/ws"
   },
   "dependencies": {

--- a/examples/electron-ts-i18n/src/electron.ts
+++ b/examples/electron-ts-i18n/src/electron.ts
@@ -1,60 +1,57 @@
-const electron = require('electron')
-// Module to control application life.
-const app = electron.app
-// Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
-
-const path = require('path')
-const url = require('url')
+import { app, BrowserWindow } from 'electron';
+import { join } from 'path';
+import { format } from 'url';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow
+let mainWindow;
 
-function createWindow () {
+function createWindow() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+  mainWindow = new BrowserWindow({ width: 800, height: 600 });
 
   // and load the index.html of the app.
-  mainWindow.loadURL(url.format({
-    pathname: path.join(__dirname, 'dist', 'index.html'),
-    protocol: 'file:',
-    slashes: true
-  }))
+  mainWindow.loadURL(
+    format({
+      pathname: join(__dirname, 'index.html'),
+      protocol: 'file:',
+      slashes: true
+    })
+  );
 
   // Open the DevTools.
-  mainWindow.webContents.openDevTools()
+  mainWindow.webContents.openDevTools();
 
   // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
+  mainWindow.on('closed', function() {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-    mainWindow = null
-  })
+    mainWindow = null;
+  });
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on('ready', createWindow);
 
 // Quit when all windows are closed.
-app.on('window-all-closed', function () {
+app.on('window-all-closed', function() {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
-app.on('activate', function () {
+app.on('activate', function() {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {
-    createWindow()
+    createWindow();
   }
-})
+});
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/examples/electron-ts/package.json
+++ b/examples/electron-ts/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "postinstall": "electron-rebuild",
-    "start": "electron .",
+    "start": "electron dist/electron.js",
     "ws": "node ../../bin/ws"
   },
   "dependencies": {

--- a/examples/electron-ts/src/electron.ts
+++ b/examples/electron-ts/src/electron.ts
@@ -1,60 +1,57 @@
-const electron = require('electron')
-// Module to control application life.
-const app = electron.app
-// Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
-
-const path = require('path')
-const url = require('url')
+import { app, BrowserWindow } from 'electron';
+import { join } from 'path';
+import { format } from 'url';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow
+let mainWindow;
 
-function createWindow () {
+function createWindow() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+  mainWindow = new BrowserWindow({ width: 800, height: 600 });
 
   // and load the index.html of the app.
-  mainWindow.loadURL(url.format({
-    pathname: path.join(__dirname, 'dist', 'index.html'),
-    protocol: 'file:',
-    slashes: true
-  }))
+  mainWindow.loadURL(
+    format({
+      pathname: join(__dirname, 'index.html'),
+      protocol: 'file:',
+      slashes: true
+    })
+  );
 
   // Open the DevTools.
-  mainWindow.webContents.openDevTools()
+  mainWindow.webContents.openDevTools();
 
   // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
+  mainWindow.on('closed', function() {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-    mainWindow = null
-  })
+    mainWindow = null;
+  });
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on('ready', createWindow);
 
 // Quit when all windows are closed.
-app.on('window-all-closed', function () {
+app.on('window-all-closed', function() {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
-app.on('activate', function () {
+app.on('activate', function() {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {
-    createWindow()
+    createWindow();
   }
-})
+});
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/src/lib/webpack/electron.ts
+++ b/src/lib/webpack/electron.ts
@@ -15,11 +15,15 @@ import {
 import { project } from '../../project';
 
 export const getElectronDevOptions = (): Array<WebpackSingleConfig> => {
-  const defaultConfig = {
+  const mainProcessConfig: WebpackSingleConfig = {
+    entry: {
+      electron: project.ws.srcElectronEntry
+    },
     output: {
       ...outputDev,
       filename: '[name].js'
     },
+    target: 'electron-main',
     node: {
       __dirname: false,
       __filename: false
@@ -28,26 +32,23 @@ export const getElectronDevOptions = (): Array<WebpackSingleConfig> => {
     plugins: [indexHtmlPlugin, extractCssPlugin, loaderOptionsPlugin],
     externals: project.ws.externals ? [project.ws.externals] : [],
     resolveLoader,
+    performance: {
+      hints: false
+    },
     resolve,
     devtool
   };
 
-  return ([
+  return [
+    mainProcessConfig,
     {
-      ...defaultConfig,
-      target: 'electron-main',
-      entry: {
-        electron: project.ws.srcElectronEntry
-      }
-    },
-    {
-      ...defaultConfig,
+      ...mainProcessConfig,
       target: 'electron-renderer',
       entry: {
         index: project.ws.srcEntry
       }
     }
-  ] as any) as Array<WebpackSingleConfig>;
+  ];
 };
 
 export const getElectronReleaseOptions = () => {

--- a/src/lib/webpack/electron.ts
+++ b/src/lib/webpack/electron.ts
@@ -14,31 +14,49 @@ import {
 } from './options';
 import { project } from '../../project';
 
-export const getElectronDevOptions = (): WebpackSingleConfig => ({
-  entry: project.ws.srcEntry,
-  output: {
-    ...outputDev,
-    filename: '[name].js'
-  },
-  module: getModuleConfig('build'),
-  plugins: [indexHtmlPlugin, extractCssPlugin, loaderOptionsPlugin],
-  target: 'electron',
-  externals: project.ws.externals ? [project.ws.externals] : [],
-  performance: {
-    hints: false
-  },
-  resolveLoader,
-  resolve,
-  devtool
-});
+export const getElectronDevOptions = (): Array<WebpackSingleConfig> => {
+  const defaultConfig = {
+    output: {
+      ...outputDev,
+      filename: '[name].js'
+    },
+    node: {
+      __dirname: false,
+      __filename: false
+    },
+    module: getModuleConfig('build'),
+    plugins: [indexHtmlPlugin, extractCssPlugin, loaderOptionsPlugin],
+    externals: project.ws.externals ? [project.ws.externals] : [],
+    resolveLoader,
+    resolve,
+    devtool
+  };
+
+  return ([
+    {
+      ...defaultConfig,
+      target: 'electron-main',
+      entry: {
+        electron: project.ws.srcElectronEntry
+      }
+    },
+    {
+      ...defaultConfig,
+      target: 'electron-renderer',
+      entry: {
+        index: project.ws.srcEntry
+      }
+    }
+  ] as any) as Array<WebpackSingleConfig>;
+};
 
 export const getElectronReleaseOptions = () => {
   const options = getElectronDevOptions();
 
-  return {
-    ...options,
-    plugins: [...options.plugins!, defineProductionPlugin]
-  };
+  return options.map(config => ({
+    ...config,
+    plugins: [...config.plugins!, defineProductionPlugin]
+  }));
 };
 
 export const electronUnitOptions: WebpackSingleConfig = {
@@ -46,7 +64,7 @@ export const electronUnitOptions: WebpackSingleConfig = {
   output: outputTest,
   module: getModuleConfig('unit'),
   plugins: [extractCssPlugin, loaderOptionsPlugin],
-  target: 'electron',
+  target: 'electron-renderer',
   externals: enzymeExternals.concat(
     project.ws.externals ? [project.ws.externals] : []
   ),

--- a/src/project.ts
+++ b/src/project.ts
@@ -140,6 +140,11 @@ export interface WsConfig {
    */
   srcEntry: string;
   /**
+   * The entry file for your electron main process code. This value is set automatically.
+   * It could look this: `./src/electron.ts`.
+   */
+  srcElectronEntry: string;
+  /**
    * The _optional_ entry file for source code at the root level of a localized spa.
    * This value is set automatically.
    * It could look this: `./src/index.i18n.ts`.
@@ -309,6 +314,9 @@ export function validate(pkg: any): PackageConfig {
   pkg.ws.srcEntry = `./${pkg.ws.srcDir}/index.${pkg.ws.entryExtension}`;
   pkg.ws.srcI18nEntry = `./${pkg.ws.srcDir}/index.i18n.${pkg.ws
     .entryExtension}`;
+  pkg.ws.srcElectronEntry = `./${pkg.ws.srcDir}/electron.${!tsconfig
+    ? 'js'
+    : 'ts'}`;
   pkg.ws.unitEntry = `./${pkg.ws.testsDir}/unit.${pkg.ws.entryExtension}`;
   pkg.ws.e2eEntry = `./${pkg.ws.testsDir}/e2e.${pkg.ws.entryExtension}`;
 


### PR DESCRIPTION
This PR enhances the electron development experience with ```@mercateo/ws```.
It allows you to create a ```electron.{js|ts}``` file within your source folder (srcElectronEntry) which is built with webpacks ```electron-main``` target. Your UI will be webpacked with ```electron-renderer``` as target. 

This is especially useful as starting at version 1.6.10 electron ships with built-in type definitions.

See updated examples :)