### PR TITLE
Make publicPath configurable

### DIFF
--- a/src/lib/webpack/browser.ts
+++ b/src/lib/webpack/browser.ts
@@ -23,7 +23,6 @@ export const getBrowserDevOptions = (): WebpackSingleConfig => ({
   // this is not really useful until then
   output: {
     ...outputDev,
-    publicPath: '/',
     libraryTarget: 'umd',
     library: project.name
   },

--- a/src/lib/webpack/options.ts
+++ b/src/lib/webpack/options.ts
@@ -30,6 +30,7 @@ export type WebpackConfig = WebpackSingleConfig | Array<WebpackSingleConfig>;
 export const nodeSourceMapEntry = 'source-map-support/register';
 
 export const output = {
+  publicPath: project.ws.publicPath,
   filename: 'index.js',
   // removes tabs (better for multiline strings)
   sourcePrefix: ''

--- a/src/lib/webpack/spa.ts
+++ b/src/lib/webpack/spa.ts
@@ -26,7 +26,6 @@ export const getSpaDevOptions = (): WebpackSingleConfig => ({
   entry: project.ws.srcEntry,
   output: {
     ...outputDev,
-    publicPath: '/',
     libraryTarget: 'umd',
     filename: '[name].js'
   },

--- a/src/project.ts
+++ b/src/project.ts
@@ -177,6 +177,12 @@ export interface WsConfig {
    */
   distReleaseDir: string;
   /**
+   * SPA only.
+   * Public path of your app. Defaults to `""`
+   * See https://webpack.js.org/configuration/output/#output-publicpath for an explanation.
+   */
+  publicPath: string;
+  /**
    * `targets` taken from [`babel-preset-env`](https://github.com/babel/babel-preset-env).
    * We only use `browsers` and `node` properties for now.
    */
@@ -319,6 +325,10 @@ export function validate(pkg: any): PackageConfig {
     : 'ts'}`;
   pkg.ws.unitEntry = `./${pkg.ws.testsDir}/unit.${pkg.ws.entryExtension}`;
   pkg.ws.e2eEntry = `./${pkg.ws.testsDir}/e2e.${pkg.ws.entryExtension}`;
+
+  if (!pkg.ws.publicPath) {
+    pkg.ws.publicPath = '';
+  }
 
   // defaults for browsers
   if (!pkg.ws.targets) {


### PR DESCRIPTION
This PR adds ```publicPath``` to your package.json. It defaults to (webpack's default) `''`.

This is necessary for proper asset referencing.
```
<img src={require('./my-picture.jpg')}/>
```

If ```publicPath``` set to X it results in Y:
* `''` => ```<img src="my-picture.jpg"/>```
* `"/"` => ```<img src="/my-picture.jpg"/>```
* `'/assets/` => ```<img src="/assets/my-picture.jpg"/>```

An empty string as a starting point is a good choice, but it collides somehow with the real world. If you use the History API for in-app routing for example. 

Real world example:
You serve your SPA from ```example.com``` and you add a route ```example.com/about``` with the above mentioned image tag. Your image will not show up because it refers to ```example.com/about/my-picture.jpg```, but physically it is located at ```example.com/my-picture.jpg```. If you set ```publicPath``` to ```/``` (server relative) it starts working as expected. 
Forward slash works for most use cases unless you serve your SPA from a subdirectory (```example.com/my-spa``` => ```publicPath: '/my-spa/'```)