### PR TITLE
serve SPA from publicPath

### DIFF
--- a/src/lib/express.ts
+++ b/src/lib/express.ts
@@ -11,7 +11,8 @@ export async function listenAsync(
 ) {
   const app = express();
 
-  middlewares.push(express.static(root));
+  app.use(project.ws.publicPath, express.static(root));
+
   middlewares.push(fallback('index.html', { root }));
 
   for (const middleware of middlewares) {


### PR DESCRIPTION
This PR enhances the publicPath feature to ensure same behavior in dev/prod environments.

For example:
publicPath=/ -> will be served from localhost:8080/
publicPath=/home/ -> will be served from localhost:8080/home/

Tested within some larger SPAs :)