### PR TITLE
Feature/tests pattern

### DIFF
--- a/src/actions/build.ts
+++ b/src/actions/build.ts
@@ -37,27 +37,27 @@ export default async function build(options: BuildOptions) {
   // build
   switch (project.ws.type) {
     case TYPE.NODE:
-      await compileAsync(getNodeBuildConfig(options), 'build');
+      await compileAsync(await getNodeBuildConfig(options), 'build');
       break;
     case TYPE.ELECTRON:
       if (options.production) {
-        await compileAsync(getElectronReleaseConfig(options), 'build -p');
+        await compileAsync(await getElectronReleaseConfig(options), 'build -p');
       } else {
-        await compileAsync(getElectronBuildConfig(options), 'build');
+        await compileAsync(await getElectronBuildConfig(options), 'build');
       }
       break;
     case TYPE.SPA:
       if (options.production) {
-        await compileAsync(getSpaReleaseConfig(options), 'build -p');
+        await compileAsync(await getSpaReleaseConfig(options), 'build -p');
       } else {
-        await compileAsync(getSpaBuildConfig(options), 'build');
+        await compileAsync(await getSpaBuildConfig(options), 'build');
       }
       break;
     case TYPE.BROWSER:
       if (options.production) {
-        await compileAsync(getBrowserReleaseConfig(options), 'build -p');
+        await compileAsync(await getBrowserReleaseConfig(options), 'build -p');
       } else {
-        await compileAsync(getBrowserBuildConfig(options), 'build');
+        await compileAsync(await getBrowserBuildConfig(options), 'build');
       }
       break;
   }

--- a/src/actions/e2e.ts
+++ b/src/actions/e2e.ts
@@ -79,7 +79,7 @@ async function init(options: BaseOptions) {
   }
 
   await removeAsync(project.ws.distTestsDir);
-  await compileAsync(getSpaE2eConfig(options), 'e2e');
+  await compileAsync(await getSpaE2eConfig(options), 'e2e');
   debug(`Build E2E tests.`);
 
   // prepare selenium
@@ -128,7 +128,7 @@ async function init(options: BaseOptions) {
 }
 
 async function run(options: BaseOptions) {
-  const { output } = getSpaE2eConfig(options);
+  const { output } = await getSpaE2eConfig(options);
   const files = [join(output.path, 'index.js')];
   const exitCode = await testAsync(files);
   if (exitCode !== 0) {

--- a/src/actions/unit.ts
+++ b/src/actions/unit.ts
@@ -1,4 +1,4 @@
-import { warn, info } from 'loglevel';
+import { warn } from 'loglevel';
 import path from 'path';
 import { removeAsync, existsAsync } from 'fs-extra-promise';
 import chalk from 'chalk';

--- a/src/actions/unit.ts
+++ b/src/actions/unit.ts
@@ -1,4 +1,4 @@
-import { warn } from 'loglevel';
+import { warn, info } from 'loglevel';
 import path from 'path';
 import { removeAsync, existsAsync } from 'fs-extra-promise';
 import chalk from 'chalk';
@@ -39,21 +39,22 @@ export default async function unit(options: UnitOptions) {
   let exitCode = 0;
   switch (project.ws.type) {
     case TYPE.NODE:
-      const config = getNodeUnitConfig(options);
+      const config = await getNodeUnitConfig(options);
       await compileAsync(config, 'unit');
       const files = [path.join(config.output.path, 'index.js')];
       exitCode = await mochaTestAsync(files);
       break;
     case TYPE.ELECTRON:
-      await compileAsync(getElectronUnitConfig(options), 'unit');
+      await compileAsync(await getElectronUnitConfig(options), 'unit');
       exitCode = await karmaTestAsync(options);
       break;
     case TYPE.SPA:
-      await compileAsync(getSpaUnitConfig(options), 'unit');
+      const conf = await getSpaUnitConfig(options);
+      await compileAsync(conf, 'unit');
       exitCode = await karmaTestAsync(options);
       break;
     case TYPE.BROWSER:
-      await compileAsync(getBrowserUnitConfig(options), 'unit');
+      await compileAsync(await getBrowserUnitConfig(options), 'unit');
       exitCode = await karmaTestAsync(options);
       break;
   }

--- a/src/actions/watch.ts
+++ b/src/actions/watch.ts
@@ -36,7 +36,7 @@ async function watchHot(options: WatchOptions) {
     await compileI18n();
   }
 
-  const config = getSpaBuildConfig(options);
+  const config = await getSpaBuildConfig(options);
   const { index } = config.entry;
   config.entry.index = [
     'react-hot-loader/patch',
@@ -89,7 +89,7 @@ export default async function watch(options: WatchOptions) {
     case TYPE.NODE:
       await watchAsync(
         livereloadServer,
-        getNodeBuildConfig(options),
+        await getNodeBuildConfig(options),
         'build',
         onChangeSuccess
       );
@@ -97,7 +97,7 @@ export default async function watch(options: WatchOptions) {
     case TYPE.ELECTRON:
       await watchAsync(
         livereloadServer,
-        getElectronBuildConfig(options),
+        await getElectronBuildConfig(options),
         'build',
         onChangeSuccess
       );
@@ -106,7 +106,7 @@ export default async function watch(options: WatchOptions) {
     case TYPE.SPA:
       await watchAsync(
         livereloadServer,
-        getSpaBuildConfig(options),
+        await getSpaBuildConfig(options),
         'build',
         onChangeSuccess
       );
@@ -115,7 +115,7 @@ export default async function watch(options: WatchOptions) {
     case TYPE.BROWSER:
       await watchAsync(
         livereloadServer,
-        getBrowserBuildConfig(options),
+        await getBrowserBuildConfig(options),
         'build',
         onChangeSuccess
       );

--- a/src/lib/webpack/browser.ts
+++ b/src/lib/webpack/browser.ts
@@ -9,7 +9,9 @@ import {
 } from './options';
 import { BaseOptions } from '../../options';
 
-export const getBrowserBuildConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getBrowserBuildConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...await getEntryAndOutput('browser', 'build'),
   ...getModuleAndPlugins('browser', 'build', options),
@@ -26,7 +28,9 @@ export const getBrowserReleaseConfig = async (
   externals: externalsBrowser
 });
 
-export const getBrowserUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getBrowserUnitConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...await getEntryAndOutput('browser', 'unit'),
   ...getModuleAndPlugins('browser', 'unit', options),

--- a/src/lib/webpack/browser.ts
+++ b/src/lib/webpack/browser.ts
@@ -9,26 +9,26 @@ import {
 } from './options';
 import { BaseOptions } from '../../options';
 
-export const getBrowserBuildConfig = (options: BaseOptions): WebpackConfig => ({
+export const getBrowserBuildConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
-  ...getEntryAndOutput('browser', 'build'),
+  ...await getEntryAndOutput('browser', 'build'),
   ...getModuleAndPlugins('browser', 'build', options),
   externals: externalsBrowser
 });
 
-export const getBrowserReleaseConfig = (
+export const getBrowserReleaseConfig = async (
   options: BaseOptions
-): WebpackConfig => ({
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...releaseConfig,
-  ...getEntryAndOutput('browser', 'build -p'),
+  ...await getEntryAndOutput('browser', 'build -p'),
   ...getModuleAndPlugins('browser', 'build -p', options),
   externals: externalsBrowser
 });
 
-export const getBrowserUnitConfig = (options: BaseOptions): WebpackConfig => ({
+export const getBrowserUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
-  ...getEntryAndOutput('browser', 'unit'),
+  ...await getEntryAndOutput('browser', 'unit'),
   ...getModuleAndPlugins('browser', 'unit', options),
   externals: enzymeExternals
 });

--- a/src/lib/webpack/electron.ts
+++ b/src/lib/webpack/electron.ts
@@ -10,54 +10,54 @@ import {
 } from './options';
 import { BaseOptions } from '../../options';
 
-export const getElectronBuildConfig = (
+export const getElectronBuildConfig = async (
   options: BaseOptions
-): WebpackConfig[] => {
-  const mainConfig: WebpackConfig = {
+): Promise<WebpackConfig[]> => {
+  const mainConfig: WebpackConfig = await {
     ...baseConfig,
     ...electronMainConfig,
-    ...getEntryAndOutput('electron-main', 'build'),
+    ...await getEntryAndOutput('electron-main', 'build'),
     ...getModuleAndPlugins('electron-main', 'build', options),
     externals: externalsSpa // is this needed here?
   };
 
-  const rendererConfig: WebpackConfig = {
+  const rendererConfig: WebpackConfig = await {
     ...baseConfig,
     ...electronRendererConfig,
-    ...getEntryAndOutput('electron-renderer', 'build'),
+    ...await getEntryAndOutput('electron-renderer', 'build'),
     ...getModuleAndPlugins('electron-renderer', 'build', options),
     externals: externalsSpa // is this needed here?
   };
 
-  return [mainConfig, rendererConfig];
+  return Promise.resolve([mainConfig, rendererConfig]);
 };
 
-export const getElectronReleaseConfig = (
+export const getElectronReleaseConfig = async (
   options: BaseOptions
-): WebpackConfig[] => {
-  const mainConfig: WebpackConfig = {
+): Promise<WebpackConfig[]> => {
+  const mainConfig: WebpackConfig = await {
     ...baseConfig,
     ...electronMainConfig,
-    ...getEntryAndOutput('electron-main', 'build -p'),
+    ...await getEntryAndOutput('electron-main', 'build -p'),
     ...getModuleAndPlugins('electron-main', 'build -p', options),
     externals: externalsSpa // is this needed here?
   };
 
-  const rendererConfig: WebpackConfig = {
+  const rendererConfig: WebpackConfig = await {
     ...baseConfig,
     ...electronRendererConfig,
-    ...getEntryAndOutput('electron-renderer', 'build -p'),
+    ...await getEntryAndOutput('electron-renderer', 'build -p'),
     ...getModuleAndPlugins('electron-renderer', 'build -p', options),
     externals: externalsSpa // is this needed here?
   };
 
-  return [mainConfig, rendererConfig];
+  return Promise.resolve([mainConfig, rendererConfig]);
 };
 
-export const getElectronUnitConfig = (options: BaseOptions): WebpackConfig => ({
+export const getElectronUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...electronRendererConfig,
-  ...getEntryAndOutput('electron-renderer', 'unit'),
+  ...await getEntryAndOutput('electron-renderer', 'unit'),
   ...getModuleAndPlugins('electron-renderer', 'unit', options),
   externals: enzymeExternals
 });

--- a/src/lib/webpack/electron.ts
+++ b/src/lib/webpack/electron.ts
@@ -54,7 +54,9 @@ export const getElectronReleaseConfig = async (
   return Promise.resolve([mainConfig, rendererConfig]);
 };
 
-export const getElectronUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getElectronUnitConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...electronRendererConfig,
   ...await getEntryAndOutput('electron-renderer', 'unit'),

--- a/src/lib/webpack/node.ts
+++ b/src/lib/webpack/node.ts
@@ -7,16 +7,16 @@ import {
 } from './options';
 import { BaseOptions } from '../../options';
 
-export const getNodeBuildConfig = (options: BaseOptions): WebpackConfig => ({
+export const getNodeBuildConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...nodeConfig,
-  ...getEntryAndOutput('node', 'build'),
+  ...await getEntryAndOutput('node', 'build'),
   ...getModuleAndPlugins('node', 'build', options)
 });
 
-export const getNodeUnitConfig = (options: BaseOptions): WebpackConfig => ({
+export const getNodeUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...nodeConfig,
-  ...getEntryAndOutput('node', 'unit'),
+  ...await getEntryAndOutput('node', 'unit'),
   ...getModuleAndPlugins('node', 'unit', options)
 });

--- a/src/lib/webpack/node.ts
+++ b/src/lib/webpack/node.ts
@@ -7,14 +7,18 @@ import {
 } from './options';
 import { BaseOptions } from '../../options';
 
-export const getNodeBuildConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getNodeBuildConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...nodeConfig,
   ...await getEntryAndOutput('node', 'build'),
   ...getModuleAndPlugins('node', 'build', options)
 });
 
-export const getNodeUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getNodeUnitConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...nodeConfig,
   ...await getEntryAndOutput('node', 'unit'),

--- a/src/lib/webpack/options.ts
+++ b/src/lib/webpack/options.ts
@@ -1,5 +1,4 @@
 import { join } from 'path';
-import { warn, info } from 'loglevel';
 import globby from 'globby';
 import { pull } from 'lodash';
 import webpack, {
@@ -470,11 +469,10 @@ export const getEntryAndOutput = async (target: Target, command: Command) => {
   if (command === 'build -p') {
     output.path = join(process.cwd(), project.ws.distReleaseDir);
   } else if (command === 'unit') {
-    const pattern = Array.isArray(project.ws.testsPattern) ? project.ws.testsPattern : [project.ws.testsPattern]
-    entry.index = await globby([
-      project.ws.unitEntry,
-      ...pattern
-    ]);
+    const pattern = Array.isArray(project.ws.testsPattern)
+      ? project.ws.testsPattern
+      : [project.ws.testsPattern];
+    entry.index = await globby([project.ws.unitEntry, ...pattern]);
     output.path = join(process.cwd(), project.ws.distTestsDir);
   } else if (command === 'e2e') {
     entry.index = project.ws.e2eEntry;

--- a/src/lib/webpack/spa.ts
+++ b/src/lib/webpack/spa.ts
@@ -10,30 +10,30 @@ import {
 } from './options';
 import { BaseOptions } from '../../options';
 
-export const getSpaBuildConfig = (options: BaseOptions): WebpackConfig => ({
+export const getSpaBuildConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
-  ...getEntryAndOutput('spa', 'build'),
+  ...await getEntryAndOutput('spa', 'build'),
   ...getModuleAndPlugins('spa', 'build', options),
   externals: externalsSpa
 });
 
-export const getSpaReleaseConfig = (options: BaseOptions): WebpackConfig => ({
+export const getSpaReleaseConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...releaseConfig,
-  ...getEntryAndOutput('spa', 'build -p'),
+  ...await getEntryAndOutput('spa', 'build -p'),
   ...getModuleAndPlugins('spa', 'build -p', options)
 });
 
-export const getSpaUnitConfig = (options: BaseOptions): WebpackConfig => ({
+export const getSpaUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
-  ...getEntryAndOutput('spa', 'unit'),
+  ...await getEntryAndOutput('spa', 'unit'),
   ...getModuleAndPlugins('spa', 'unit', options),
   externals: enzymeExternals
 });
 
-export const getSpaE2eConfig = (options: BaseOptions): WebpackConfig => ({
+export const getSpaE2eConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...nodeConfig,
-  ...getEntryAndOutput('node', 'e2e'),
+  ...await getEntryAndOutput('node', 'e2e'),
   ...getModuleAndPlugins('node', 'e2e', options)
 });

--- a/src/lib/webpack/spa.ts
+++ b/src/lib/webpack/spa.ts
@@ -10,28 +10,36 @@ import {
 } from './options';
 import { BaseOptions } from '../../options';
 
-export const getSpaBuildConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getSpaBuildConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...await getEntryAndOutput('spa', 'build'),
   ...getModuleAndPlugins('spa', 'build', options),
   externals: externalsSpa
 });
 
-export const getSpaReleaseConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getSpaReleaseConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...releaseConfig,
   ...await getEntryAndOutput('spa', 'build -p'),
   ...getModuleAndPlugins('spa', 'build -p', options)
 });
 
-export const getSpaUnitConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getSpaUnitConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...await getEntryAndOutput('spa', 'unit'),
   ...getModuleAndPlugins('spa', 'unit', options),
   externals: enzymeExternals
 });
 
-export const getSpaE2eConfig = async (options: BaseOptions): Promise<WebpackConfig> => ({
+export const getSpaE2eConfig = async (
+  options: BaseOptions
+): Promise<WebpackConfig> => ({
   ...baseConfig,
   ...nodeConfig,
   ...await getEntryAndOutput('node', 'e2e'),

--- a/src/project.ts
+++ b/src/project.ts
@@ -156,6 +156,10 @@ export interface WsConfig {
    */
   testsDir: string;
   /**
+   * The pattern that is used to find tests
+   */
+  testsPattern: string | string[];
+  /**
    * The entry file for your unit tests. This value is set automatically.
    * It could look this: `./tests/unit.ts`.
    */


### PR DESCRIPTION
Related to #28 

This allows to avoid a single point of entry (one directory & file where all the unit tests have to be imported). Instead, **you are able to place the unit tests in different folders (and subfolders**): for example directly next to the source file.

**Example**: If you had a `'src/shop/list.ts'` you could create `'src/shop/__tests__/list-test.ts'` and test it by providing the ws option: `"testsPattern": "./src/**/__tests__/**/*-test.ts"` in package.json.

`testsPattern` also allows an array of patterns.:
```
"testsPattern": [
  "./src/**/__tests__/**/*-test.ts",
  "./src/**/__tests__/**/*-test.tsx"
]
```

The most relevant change is in ` src/lib/webpack/options.ts`, other refactorings were necessary because I made `getEntryAndOutput` async :-)