### PR TITLE
Remove no-unused-variable rule as this is covered by TS 2.9

### DIFF
--- a/packages/ws/tslint.json
+++ b/packages/ws/tslint.json
@@ -12,7 +12,6 @@
     "no-reference": true,
     "no-var-keyword": true,
     "no-unused-expression": true,
-    "no-unused-variable": [true, { "ignore-pattern": "^_" }],
     "object-literal-shorthand": true,
     "prefer-for-of": true,
     "triple-equals": [true, "allow-null-check"]


### PR DESCRIPTION
We had some problems with the no-unused-variable rule from TSLint in connection with generic parameters for string templates.
As Typescript supports "noUnusedParameters" and "noUnusedLocals" should cover the rule, we should be able to replace this in tsconfigs.