### PR TITLE
Fix externalsNode configuration for workspace-based projects

### DIFF
--- a/packages/ws/src/lib/webpack/options.ts
+++ b/packages/ws/src/lib/webpack/options.ts
@@ -353,11 +353,18 @@ export const externalsNode = [
       callback();
     }
   },
-  // in order to ignore all modules in node_modules folder
-  WebpackNodeExternals({
-    modulesDir: isWorkspace ? join(process.cwd(), '..', '..') : undefined
-  })
+  // default "node_modules" dir is excluded
+  WebpackNodeExternals()
 ];
+
+if (isWorkspace) {
+  // ignore all modules in node_modules workspace root folder
+  externalsNode.push(
+    WebpackNodeExternals({
+      modulesDir: join(process.cwd(), '..', '..', 'node_modules')
+    })
+  );
+}
 
 export const externalsBrowser = [
   (_context: any, request: any, callback: any) => {


### PR DESCRIPTION
Hi there,

I was trying to move a typescript node.js project to yarn workspace-based project and ran into an issue: the code has been bundled, however threw errors. 

This seems to be a small PR change, however I tried to rebuild the problem scenario and added description on reproducing the problem and solution suggestion in a small demo-project in my repository [here](https://github.com/akvamalin/problem-showcases/tree/master/ws-node-webpack-config-fails). 

I would appreciate to have this merged so that I can stick to using this tool in other projects.

Best regards :)